### PR TITLE
1) Fix log loss scenario during rebalance, 2) use api version 0 inste…

### DIFF
--- a/src/KafkaNET.Library/Consumers/ConsumerIterator.cs
+++ b/src/KafkaNET.Library/Consumers/ConsumerIterator.cs
@@ -247,7 +247,7 @@ namespace Kafka.Client.Consumers
                 currentTopicInfo = currentDataChunk.TopicInfo;
                 Logger.DebugFormat("CurrentTopicInfo: ConsumedOffset({0}), FetchOffset({1})",
                                     currentTopicInfo.ConsumeOffset, currentTopicInfo.FetchOffset);
-                if (currentTopicInfo.ConsumeOffset != currentDataChunk.FetchOffset)
+                if (currentTopicInfo.FetchOffset < currentDataChunk.FetchOffset)
                 {
                     Logger.ErrorFormat("consumed offset: {0} doesn't match fetch offset: {1} for {2}; consumer may lose data",
                         currentTopicInfo.ConsumeOffset,

--- a/src/KafkaNET.Library/Consumers/PartitionTopicInfo.cs
+++ b/src/KafkaNET.Library/Consumers/PartitionTopicInfo.cs
@@ -232,8 +232,8 @@ namespace Kafka.Client.Consumers
 
                 Logger.InfoFormat("{2} : Updating fetch offset = {0} with value = {1}", this.fetchedOffset, offset, this.PartitionId);
                 this.chunkQueue.Add(new FetchedDataChunk(messages, this, this.fetchedOffset));
-                long newOffset = Interlocked.Exchange(ref this.fetchedOffset, offset);
-                Logger.Debug("Updated fetch offset of " + this + " to " + newOffset);
+                Interlocked.Exchange(ref this.fetchedOffset, offset);
+                Logger.Debug("Updated fetch offset of " + this + " to " + offset);
             }
 
             return size;

--- a/src/KafkaNET.Library/Messages/BufferedMessageSet.cs
+++ b/src/KafkaNET.Library/Messages/BufferedMessageSet.cs
@@ -316,7 +316,7 @@ namespace Kafka.Client.Messages
                 return AllDone();
             }
 
-            Message newMessage = this.Messages.ToList()[topIterPosition];
+            Message newMessage = this.Messages.ElementAt(topIterPosition);
             lastMessageSize = newMessage.Size;
             topIterPosition++;
             switch (newMessage.CompressionCodec)

--- a/src/KafkaNET.Library/Requests/FetchRequest.cs
+++ b/src/KafkaNET.Library/Requests/FetchRequest.cs
@@ -56,7 +56,7 @@ namespace Kafka.Client.Requests
         public const byte DefaultMinBytesSize = 4;
         public const byte DefaultOffsetInfoSizeSize = 4;
 
-        public const short CurrentVersion = 1;
+        public const short CurrentVersion = 0;
 
         public FetchRequest(int correlationId, string clientId, int maxWait, int minBytes, Dictionary<string, List<PartitionFetchInfo>> fetchInfos)
         {


### PR DESCRIPTION
Major Fix: Log loss scenario which happens when a Kafka connection error happens during re-balance and auto offset reset is enabled to latest

Change requests to use API version 0 instead of 1. This will let the library be usable in 0.9

Minor fixes: Some small logging bugs and performance related fix