### PR TITLE
Add a destructor to close the underlying connection

### DIFF
--- a/src/KafkaNET.Library/Consumers/FetcherRunnable.cs
+++ b/src/KafkaNET.Library/Consumers/FetcherRunnable.cs
@@ -221,5 +221,13 @@ namespace Kafka.Client.Consumers
 
             return offsetFound;
         }
+
+        ~FetcherRunnable()
+        {
+            if (_simpleConsumer != null)
+            {
+                _simpleConsumer.Dispose();
+            }
+        }
     }
 }


### PR DESCRIPTION
The long-term fix would be to make FetcherRunnable a Disposable object, but the destructor might provide a quick relief to kafka connection leaks.