### PR TITLE
Optimization and bubble up the ProducerResponseStatus to producer.Sen…

### DIFF
--- a/src/KafkaNET.Library/Producers/ICallbackHandler.cs
+++ b/src/KafkaNET.Library/Producers/ICallbackHandler.cs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+using Kafka.Client.Responses;
+
 namespace Kafka.Client.Producers
 {
     using System;
@@ -30,6 +32,6 @@ namespace Kafka.Client.Producers
         /// <param name="events">
         /// The sent request events.
         /// </param>
-        void Handle(IEnumerable<ProducerData<K,V>> events);
+        List<ProducerResponseStatus> Handle(IEnumerable<ProducerData<K,V>> events);
     }
 }

--- a/src/KafkaNET.Library/Producers/IProducer.cs
+++ b/src/KafkaNET.Library/Producers/IProducer.cs
@@ -16,6 +16,7 @@
  */
 
 using System.Collections.Generic;
+using Kafka.Client.Responses;
 
 namespace Kafka.Client.Producers
 {
@@ -36,7 +37,7 @@ namespace Kafka.Client.Producers
         /// synchronous or the asynchronous producer.
         /// </summary>
         /// <param name="data">The producer data objects that encapsulate the topic, key and message data.</param>
-        void Send(IEnumerable<ProducerData<TKey, TData>> data);
+        List<ProducerResponseStatus> Send(IEnumerable<ProducerData<TKey, TData>> data);
 
         /// <summary>
         /// Sends the data to a single topic, partitioned by key, using either the

--- a/src/KafkaNET.Library/Producers/ProduceDispatchSeralizeResult.cs
+++ b/src/KafkaNET.Library/Producers/ProduceDispatchSeralizeResult.cs
@@ -14,17 +14,19 @@ namespace Kafka.Client.Producers
     public class ProduceDispatchSeralizeResult<K>
     {
         public ProduceDispatchSeralizeResult(IEnumerable<Exception> exceptions,
-            IEnumerable<ProducerData<K, Message>> failedProducerDatas, List<Tuple<int, TopicAndPartition, ProducerResponseStatus>> failedDetail, bool hasDataNeedDispatch)
+            IEnumerable<ProducerData<K, Message>> failedProducerDatas, List<Tuple<int, TopicAndPartition, ProducerResponseStatus>> failedDetail, bool hasDataNeedDispatch, List<ProducerResponseStatus> producerResponse = null)
         {
             Exceptions = exceptions;
             FailedProducerDatas = failedProducerDatas;
             FailedDetail = failedDetail;
             this.HasDataNeedDispatch = hasDataNeedDispatch;
+            this.ProducerResponse = producerResponse ?? new List<ProducerResponseStatus>();
         }
 
         public IEnumerable<ProducerData<K, Message>> FailedProducerDatas { get; private set; }
         public IEnumerable<Exception> Exceptions { get; private set; }
         public List<Tuple<int, TopicAndPartition, ProducerResponseStatus>> FailedDetail { get; private set; }
         public bool HasDataNeedDispatch { get; private set; }
-    }
+        public List<ProducerResponseStatus> ProducerResponse { get; private set; }
+}
 }

--- a/src/KafkaNET.Library/Producers/Producer.cs
+++ b/src/KafkaNET.Library/Producers/Producer.cs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+using Kafka.Client.Responses;
+
 namespace Kafka.Client.Producers
 {
     using Kafka.Client.Cfg;
@@ -70,14 +72,14 @@ namespace Kafka.Client.Producers
         /// Sends the data to a multiple topics, partitioned by key
         /// </summary>
         /// <param name="data">The producer data objects that encapsulate the topic, key and message data.</param>
-        public void Send(IEnumerable<ProducerData<TKey, TData>> data)
+        public List<ProducerResponseStatus> Send(IEnumerable<ProducerData<TKey, TData>> data)
         {
             Guard.NotNull(data, "data");
             Guard.CheckBool(data.Any(), true, "data.Any()");
 
             this.EnsuresNotDisposed();
 
-            this.callbackHandler.Handle(data);
+            return this.callbackHandler.Handle(data);
         }
 
         /// <summary>

--- a/src/KafkaNET.Library/Responses/ProducerResponse.cs
+++ b/src/KafkaNET.Library/Responses/ProducerResponse.cs
@@ -25,6 +25,8 @@ namespace Kafka.Client.Responses
     {
         public ErrorMapping Error { get; set; }
         public long Offset { get; set; }
+        public string Topic { get; set; }
+        public int PartitionId { get; set; }
         public override string ToString()
         {
             return string.Format("Error:{0} Offset:{1}", this.Error, this.Offset);
@@ -59,13 +61,16 @@ namespace Kafka.Client.Responses
                     {
                         var partitionId = reader.ReadInt32();
                         var error = reader.ReadInt16();
+                        //only returns first message offset per Topic and Partition pair
                         var offset = reader.ReadInt64();
                         var topicAndPartition = new TopicAndPartition(topic, partitionId);
 
                         statuses.Add(topicAndPartition, new ProducerResponseStatus()
                         {
                             Error = ErrorMapper.ToError(error),
-                            Offset = offset
+                            Offset = offset,
+                            Topic = topic,
+                            PartitionId = partitionId
                         });
 
                     }


### PR DESCRIPTION
…d method.

-Optimized DispatchSerializedData method in DefaultCallbackHandler.cs to use a single foreach method as opposed to multiple foreach statements.
-Added offset and partitionId to ProducerResponseStatus and bubbled it all the way to the producer.Send method. Kafka intended for this response to be available to the consumer for logging, health, etc.
-Added ShouldReturnOffset() unit test in DefaultCallbackHandlerTest.cs
-All Unit Tests passed