### PR TITLE
ConsumerOffset fix when OffsetOutOfRange

### DIFF
--- a/src/KafkaNET.Library/Consumers/FetcherRunnable.cs
+++ b/src/KafkaNET.Library/Consumers/FetcherRunnable.cs
@@ -80,7 +80,7 @@ namespace Kafka.Client.Consumers
             {
                 try
                 {
-                    IEnumerable<PartitionTopicInfo> fetchablePartitionTopicInfos = _partitionTopicInfos.Where(pti => pti.NextRequestOffset - pti.ConsumeOffset < _fetchBufferLength);
+                    IEnumerable<PartitionTopicInfo> fetchablePartitionTopicInfos = _partitionTopicInfos.Where(pti => pti.GetMessagesCount() < _fetchBufferLength);
 
                     long read = 0;
 
@@ -125,9 +125,7 @@ namespace Kafka.Client.Consumers
                                                                                 partitionTopicInfo.PartitionId);
                                         if (resetOffset >= 0)
                                         {
-                                            partitionTopicInfo.FetchOffset = resetOffset;
-                                            partitionTopicInfo.ConsumeOffset = resetOffset;
-
+                                            partitionTopicInfo.ResetOffset(resetOffset);
                                             Logger.InfoFormat("{0} marked as done.", partitionTopicInfo);
                                         }
                                     }

--- a/src/KafkaNET.Library/ZooKeeperIntegration/Listeners/ZKRebalancerListener.cs
+++ b/src/KafkaNET.Library/ZooKeeperIntegration/Listeners/ZKRebalancerListener.cs
@@ -518,7 +518,6 @@ namespace Kafka.Client.ZooKeeperIntegration.Listeners
                 queue,
                 offsetCommited,
                 offset,
-                offset,
                 this.config.FetchSize,
                 offsetCommited);
             partTopicInfoMap[partitionId] = partTopicInfo;


### PR DESCRIPTION
The fix is first, FetcherRunnable shouldn't just set the consumedoffset as it doesn't own how far it consumed. When FetcherRunnable detects about outofrange error, it signal PartitionTopicInfo to fix its offset. Creae a private variable lastKnownGoodNextRequestOffset for pti to save the old marker of NextRequestOffset When OutOfRange happens. In the next iteration of fetcher, use that to caculate the actual messages in the queue. After the successful fetch, it set back to align with NextRequestOffset.

Also cleaned up messageOffset as it is never being used.