### PR TITLE
Update log4net to fix Issue #57

### DIFF
--- a/src/Kafka.Client.Tests/Kafka.Client.Tests.csproj
+++ b/src/Kafka.Client.Tests/Kafka.Client.Tests.csproj
@@ -81,8 +81,8 @@
       <HintPath>..\packages\FluentAssertions.4.2.2\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
-       <HintPath>..\packages\log4net.1.2.10\lib\2.0\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />

--- a/src/Kafka.Client.Tests/packages.config
+++ b/src/Kafka.Client.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="4.2.2" targetFramework="net45" />
-  <package id="log4net" version="1.2.10" targetFramework="net45" />
+  <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="ZooKeeper.Net" version="3.4.6.2" targetFramework="net45" />
 </packages>

--- a/src/KafkaNET.Library/KafkaNET.Library.csproj
+++ b/src/KafkaNET.Library/KafkaNET.Library.csproj
@@ -141,8 +141,8 @@
     <DefineConstants>TRACE;NET45</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.1.2.10\lib\2.0\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/KafkaNET.Library/packages.config
+++ b/src/KafkaNET.Library/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="1.2.10" targetFramework="net45" />
+  <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="ZooKeeper.Net" version="3.4.6.2" targetFramework="net45" />
 </packages>

--- a/src/KafkaNETLibraryConsole/packages.config
+++ b/src/KafkaNETLibraryConsole/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="1.2.10" targetFramework="net45" />
+  <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="ZooKeeper.Net" version="3.4.6.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Issue #57 refers to log4net causing irrecoverable version conflicts due to a change in public token. Updating to the latest version appears to cause no conflicts.